### PR TITLE
Update Kemal version

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -6,5 +6,5 @@ shards:
 
   kemal:
     github: sdogruyol/kemal
-    commit: d825b2316a7ba78d5d09925174dd272d95eca259
+    commit: 64fac62804c5c232dbacad148b28a1d31bc4cbdc
 


### PR DESCRIPTION
This change updates Kemal version to be compatible with Crystal [0.10.0](https://github.com/manastech/crystal/releases/tag/0.10.0).

Before the change:

``` sh
$crystal -v
Crystal 0.10.0 (Mon Dec 28 09:26:30 UTC 2015)

$ crystal build --release src/kamber.cr
Error in ./libs/kemal/kemal.cr:35: undefined method 'working_directory' for Dir:Class

    file_path = File.expand_path("libs/kemal/images/#{image}", Dir.working_directory)
                                                                   ^~~~~~~~~~~~~~~~~
```
